### PR TITLE
feat(map-node-placement): add logic to place nodes on a map based on …

### DIFF
--- a/jobs/scripts/downloadloop.py
+++ b/jobs/scripts/downloadloop.py
@@ -6,8 +6,8 @@ sys.path.append(str(Path(__file__).resolve().parents[2]))
 #---------------------------------------------------------#
 from scripts import path
 from scripts.initialize import cities
-from scripts import prepare_networks,prepare_pois
-
+from scripts import prepare_networks,prepare_pois, cluster_pois
+from parameters.parameters import h3_zoom, snapthreshold, sanidad_slider, educacion_slider, administracion_slider, aprovisionamiento_slider, cultura_slider, deporte_slider, transporte_slider
 debug = False
 PATH = path.PATH
 
@@ -19,4 +19,7 @@ if __name__ == '__main__':
 
     print("Running 02.py")
     prepare_pois.main(PATH, cities)
+
+    print("Running 03.py")
+    cluster_pois.main(PATH, cities, h3_zoom, snapthreshold, sanidad_slider, educacion_slider, administracion_slider, aprovisionamiento_slider,cultura_slider, deporte_slider, transporte_slider)
     

--- a/parameters/parameters.py
+++ b/parameters/parameters.py
@@ -1,7 +1,7 @@
 # PARAMETERS
 # These are values to loop through for different runs
 poi_source = "grid" # railwaystation, grid
-prune_measure = "betweenness" # betweenness, closeness, random
+prune_measure ="betweenness" # betweenness, clo seness, random
 
 SERVER = False # Whether the code runs on the server (important to avoid parallel job conflicts)
 
@@ -20,9 +20,235 @@ gridl = 1707 # in m, for generating the grid
 # 2*0.5 = a+a-sqrt(2)a   |   1 = a(2-sqrt2)   |   a = 1/(2-sqrt2) = 1.707
 # This leads to a full 500m coverage when a (worst-case) square is being triangulated
 bearingbins = 72 # number of bins to determine bearing. e.g. 72 will create 5 degrees bins
-poiparameters = {"railwaystation":{'railway':['station','halt']}#, # should maybe also add: ["railway"!~"entrance"], but afaik osmnx is not capable of this: https://osmnx.readthedocs.io/en/stable/osmnx.html?highlight=geometries_from_polygon#osmnx.geometries.geometries_from_polygon
-                 #"busstop":{'highway':'bus_stop'}
-                }
+
+h3_zoom = 8
+
+# Example slider value
+
+sanidad_slider = 5  
+educacion_slider = 6
+administracion_slider = 7
+aprovisionamiento_slider = 8
+cultura_slider = 9
+deporte_slider = 10
+transporte_slider = 10
+
+poiparameters = {
+    # Sanidad (Health)
+    "hospital": {'amenity': 'hospital'},
+    "clinic": {'amenity': 'clinic'},
+    "pharmacy": {'amenity': 'pharmacy'},
+    "dentist": {'amenity': 'dentist'},
+    "veterinary": {'amenity': 'veterinary'},
+    "daycare": {'amenity': 'social_facility', 'social_facility': 'day_care'},
+    "socialservices": {'amenity': 'social_facility'},
+    "doctors": {'amenity': 'doctors'},
+    "nursing_home": {'amenity': 'nursing_home'},
+    #"optician": {'shop': 'optician'},
+
+    # Educación (Education)
+    "school": {'amenity': 'school'},
+    "university": {'amenity': 'university'},
+    "kindergarten": {'amenity': 'kindergarten'},
+    "college": {'amenity': 'college'},
+    "training": {'amenity': 'training'},
+    "language_school": {'amenity': 'language_school'},
+    "music_school": {'amenity': 'music_school'},
+
+    # Administración (Administration)
+    "townhall": {'amenity': 'townhall'},
+    "courthouse": {'amenity': 'courthouse'},
+    "police": {'amenity': 'police'},
+    "firestation": {'amenity': 'fire_station'},
+    "postoffice": {'amenity': 'post_office'},
+    "media": {'office': 'media'},
+    "embassy": {'amenity': 'embassy'},
+    "recycling": {'amenity': 'recycling'},
+
+    # Aprovisionamiento (Supplies)
+    "supermarket": {'shop': 'supermarket'},
+    "mall": {'shop': 'mall'},
+    "bakery": {'shop': 'bakery'},
+    "butcher": {'shop': 'butcher'},
+    "greengrocer": {'shop': 'greengrocer'},
+    "marketplace": {'amenity': 'marketplace'},
+    "electronics": {'shop': 'electronics'},
+    "clothes": {'shop': 'clothes'},
+    "furniture": {'shop': 'furniture'},
+    "hardware": {'shop': 'hardware'},
+    "beverages": {'shop': 'beverages'},
+    "convenience": {'shop': 'convenience'},
+
+    # Cultura/Ocio (Culture/Leisure)
+    "museum": {'tourism': 'museum'},
+    "theatre": {'amenity': 'theatre'},
+    "cinema": {'amenity': 'cinema'},
+    "library": {'amenity': 'library'},
+    "park": {'leisure': 'park'},
+    "playground": {'leisure': 'playground'},
+    "communitycentre": {'amenity': 'community_centre'},
+    "art_gallery": {'tourism': 'art_gallery'},
+    "zoo": {'tourism': 'zoo'},
+    "theme_park": {'tourism': 'theme_park'},
+
+        # Otros (Others)
+    "place_of_worship": {'amenity': 'place_of_worship'},
+    "atm": {'amenity': 'atm'},
+    "bank": {'amenity': 'bank'},
+    "restaurant": {'amenity': 'restaurant'},
+    "cafe": {'amenity': 'cafe'},
+    "bar": {'amenity': 'bar'},
+    "fast_food": {'amenity': 'fast_food'},
+    "hotel": {'tourism': 'hotel'},
+    "hostel": {'tourism': 'hostel'},
+    "camp_site": {'tourism': 'camp_site'},
+    "public_toilet": {'amenity': 'toilets'},
+    "fountain": {'amenity': 'fountain'},
+
+
+    # Deporte (Sports)
+    "sportscentre": {'leisure': 'sports_centre'},  # General sports center
+    "stadium": {'leisure': 'stadium'},  # Sports stadiums
+    "swimmingpool": {'leisure': 'swimming_pool'},  # Swimming pools
+    "pitch": {'leisure': 'pitch'},  # Sports pitches (soccer, rugby, etc.)
+    "fitnesscentre": {'leisure': 'fitness_centre'},  # Fitness gyms and centers
+    "outdoor_sports": {'leisure': 'sports'},  # General outdoor sports areas
+    "climbing": {'sport': 'climbing'},  # Rock climbing walls and facilities
+    "golf_course": {'leisure': 'golf_course'},  # Golf courses
+    "tennis": {'leisure': 'pitch', 'sport': 'tennis'},  # Tennis courts
+    "basketball": {'leisure': 'pitch', 'sport': 'basketball'},  # Basketball courts
+    "skatepark": {'leisure': 'skatepark'},  # Skateboarding parks
+    "equestrian": {'sport': 'equestrian'},  # Equestrian facilities
+    "ice_rink": {'leisure': 'ice_rink'},  # Ice skating rinks
+    "bowling": {'amenity': 'bowling_alley'},  # Bowling alleys
+    "running_track": {'leisure': 'track', 'sport': 'running'},  # Running tracks
+    "table_tennis": {'sport': 'table_tennis'},  # Table tennis facilities
+    "squash": {'sport': 'squash'},  # Squash courts
+    "volleyball": {'sport': 'volleyball'},  # Volleyball courts
+    "cricket": {'sport': 'cricket'},  # Cricket pitches
+    "baseball": {'sport': 'baseball'},  # Baseball diamonds
+    "boating": {'leisure': 'marina'},  # Boating and marinas
+    "fishing": {'leisure': 'fishing'},  # Fishing areas
+    "shooting": {'sport': 'shooting'},  # Shooting ranges
+    "archery": {'sport': 'archery'},  # Archery ranges
+    "surfing": {'sport': 'surfing'},  # Surfing spots
+    "skiing": {'sport': 'skiing'},  # Skiing facilities
+    "motor_sports": {'sport': 'motor'},  # Motor sports facilities
+    "cycling": {'sport': 'cycling'},  # Cycling tracks or paths
+    "rowing": {'sport': 'rowing'},  # Rowing facilities
+    "karate": {'sport': 'karate'},  # Karate or martial arts dojos
+    "yoga": {'sport': 'yoga'},  # Yoga centers or studios
+    "paddle": {'sport': 'paddle_tennis'},  # Paddle tennis courts
+    "rugby": {'sport': 'rugby'},  # Rugby pitches
+    "hockey": {'sport': 'hockey'},  # Hockey fields or rinks
+    "badminton": {'sport': 'badminton'},  # Badminton courts
+    "diving": {'sport': 'diving'},  # Diving facilities
+    "horse_racing": {'sport': 'horse_racing'},  # Horse racing tracks
+    "skating": {'sport': 'skating'},  # Skating rinks or facilities
+    "kitesurfing": {'sport': 'kitesurfing'},  # Kitesurfing locations
+    "paragliding": {'sport': 'paragliding'},  # Paragliding locations
+    "windsurfing": {'sport': 'windsurfing'},  # Windsurfing spots
+    "aerobics": {'sport': 'aerobics'},  # Aerobics studios
+    "parkour": {'sport': 'parkour'},  # Parkour parks or spots
+    "futsal": {'sport': 'futsal'},  # Futsal pitches
+
+    # Transporte (Transport)
+   "railwaystation": {'railway': ['station', 'halt']},  # Train stations and halts
+    "busstop": {'highway': 'bus_stop'},  # Bus stops
+    "tramstop": {'railway': 'tram_stop'},  # Tram stops
+    "subwayentrance": {'railway': 'subway_entrance'},  # Subway entrances
+    "taxistand": {'amenity': 'taxi'},  # Taxi stands
+    "parking": {'amenity': 'parking'},  # Parking lots
+    "bicyclerental": {'amenity': 'bicycle_rental'},  # Bicycle rental services
+    "car_rental": {'amenity': 'car_rental'},  # Car rental services
+    "fuel": {'amenity': 'fuel'},  # Fuel stations
+    "charging_station": {'amenity': 'charging_station'},  # EV charging stations
+    "ferry_terminal": {'amenity': 'ferry_terminal'},  # Ferry terminals
+    "aerodrome": {'aeroway': 'aerodrome'},  # Small airfields and private airports
+    "airport": {'aeroway': 'airport'},  # Airports
+    "helipad": {'aeroway': 'helipad'},  # Helipads
+    "bus_station": {'amenity': 'bus_station'},  # Bus stations
+    "coach_stop": {'amenity': 'coach_station'},  # Long-distance coach stops
+    "motorcycle_parking": {'amenity': 'motorcycle_parking'},  # Motorcycle parking areas
+    "bicycle_parking": {'amenity': 'bicycle_parking'},  # Bicycle parking areas
+    "train_crossing": {'railway': 'level_crossing'},  # Railway level crossings
+    "tramway": {'railway': 'tram'},  # Tramway infrastructure
+    "subway_station": {'railway': 'subway'},  # Subway stations
+    "monorail": {'railway': 'monorail'},  # Monorail systems
+    "light_rail": {'railway': 'light_rail'},  # Light rail stations
+    "park_and_ride": {'amenity': 'park_and_ride'},  # Park-and-ride facilities
+    "bus_shelter": {'amenity': 'shelter', 'shelter_type': 'public_transport'},  # Bus shelters
+    "cargo_terminal": {'landuse': 'depot'},  # Cargo or freight terminals
+    "container_terminal": {'man_made': 'container_terminal'},  # Shipping container terminals
+    "seaport": {'amenity': 'seaport'},  # Seaports
+    "dock": {'man_made': 'dock'},  # Docks
+    "carpool_parking": {'amenity': 'carpool_parking'},  # Carpool parking lots
+    "toll_booth": {'barrier': 'toll_booth'},  # Toll booths
+    "customs": {'amenity': 'customs'},  # Customs facilities at borders
+    "weigh_station": {'amenity': 'weighbridge'},  # Weigh stations for trucks
+    "pier": {'man_made': 'pier'},  # Piers and wharfs
+    "boat_rental": {'amenity': 'boat_rental'},  # Boat rental services
+    "canoe_rental": {'sport': 'canoe'},  # Canoe or kayak rentals
+    "car_sharing": {'amenity': 'car_sharing'},  # Car sharing services
+    "roadside_rest_area": {'highway': 'rest_area'},  # Roadside rest areas
+    "service_area": {'highway': 'services'},  # Service areas on highways
+    "bike_repair_station": {'amenity': 'bicycle_repair_station'},  # Bicycle repair stations
+    "tram_depot": {'railway': 'tram_depot'},  # Tram depots
+    "bus_depot": {'railway': 'bus_depot'},  # Bus depots
+    "cable_car": {'aerialway': 'cable_car'},  # Cable car systems
+    "gondola": {'aerialway': 'gondola'},  # Gondola lifts
+    "chair_lift": {'aerialway': 'chair_lift'},  # Chair lifts
+    "funicular": {'aerialway': 'funicular'},  # Funicular railways
+
+}
+
+
+sanidad = {    "hospital": {'amenity': 'hospital'},
+    "clinic": {'amenity': 'clinic'},
+    "pharmacy": {'amenity': 'pharmacy'},
+    "dentist": {'amenity': 'dentist'},
+    "veterinary": {'amenity': 'veterinary'}}
+
+educacion =     {"school": {'amenity': 'school'},
+    "university": {'amenity': 'university'},
+    "kindergarten": {'amenity': 'kindergarten'},
+    "college": {'amenity': 'college'}}
+
+administracion = {    "townhall": {'amenity': 'townhall'},
+    "courthouse": {'amenity': 'courthouse'},
+    "police": {'amenity': 'police'},
+    "firestation": {'amenity': 'fire_station'},
+    "postoffice": {'amenity': 'post_office'}}
+
+aprovisionamiento = { "supermarket": {'shop': 'supermarket'},
+    "mall": {'shop': 'mall'},
+    "bakery": {'shop': 'bakery'},
+    "butcher": {'shop': 'butcher'},
+    "greengrocer": {'shop': 'greengrocer'},
+    "marketplace": {'amenity': 'marketplace'}}
+
+cultura = {  "museum": {'tourism': 'museum'},
+    "theatre": {'amenity': 'theatre'},
+    "cinema": {'amenity': 'cinema'},
+    "library": {'amenity': 'library'},
+    "park": {'leisure': 'park'},
+    "playground": {'leisure': 'playground'}}
+
+deporte = {  
+    "sportscentre": {'leisure': 'sports_centre'},
+    "stadium": {'leisure': 'stadium'},
+    "swimmingpool": {'leisure': 'swimming_pool'},
+    "pitch": {'leisure': 'pitch'},
+    "fitnesscentre": {'leisure': 'fitness_centre'}}
+
+transporte = {
+    "railwaystation": {'railway': ['station', 'halt']},
+    "busstop": {'highway': 'bus_stop'},
+    "tramstop": {'railway': 'tram_stop'},
+    "subwayentrance": {'railway': 'subway_entrance'},
+    "taxistand": {'amenity': 'taxi'},
+    "parking": {'amenity': 'parking'}
+}
 
 # 04
 buffer_walk = 500 # Buffer in m for coverage calculations. (How far people are willing to walk)

--- a/scripts/cluster_pois.py
+++ b/scripts/cluster_pois.py
@@ -1,0 +1,305 @@
+#config
+from pathlib import Path
+from scripts.path import PATH
+debug = True
+
+
+# System
+import csv
+from tqdm.notebook import tqdm
+import time
+from tqdm import tqdm
+from typing import Dict, Union
+
+# Math/Data
+import math
+import numpy as np
+import pandas as pd
+from sklearn.cluster import AffinityPropagation
+from sklearn.preprocessing import StandardScaler
+
+# Plotting
+import matplotlib.pyplot as plt
+
+# Geo
+import osmnx as ox
+ox.settings.log_file = True
+ox.settings.requests_timeout = 300
+ox.settings.logs_folder = PATH["logs"]
+import fiona
+import shapely
+from haversine import haversine
+import geopandas as gpd
+import pyproj
+from shapely.geometry import Polygon
+from tobler.util import h3fy
+
+# Local
+from scripts.functions import fill_holes, extract_relevant_polygon, csv_to_ox, count_and_merge, rotate_grid, reverse_bearing
+from parameters.parameters import  gridl, bearingbins, poiparameters, osmnxparameters, snapthreshold, h3_zoom, sanidad, educacion, administracion, aprovisionamiento, cultura, deporte, transporte, sanidad_slider, educacion_slider, administracion_slider, aprovisionamiento_slider, cultura_slider, deporte_slider, transporte_slider, snapthreshold
+from scripts.initialize import cities
+
+
+
+# Example categories definition as a dictionary
+categories = {
+    "sanidad": sanidad,  # 'sanidad' should be a dictionary of POI types
+    "educacion": educacion,
+    "administracion": administracion,
+    "aprovisionamiento": aprovisionamiento,
+    "cultura": cultura,
+    "deporte": deporte,
+    "transporte": transporte
+}
+
+
+def main(
+    PATH: str,
+    cities: Dict[str, Dict[str, Union[str, None]]],
+    h3_zoom: int,
+    snapthreshold: int,
+    sanidad_slider: float,
+    educacion_slider: float,
+    administracion_slider: float,
+    aprovisionamiento_slider: float,
+    cultura_slider: float,
+    deporte_slider: float,
+    transporte_slider: float
+) -> None:
+    """
+    Process city data to generate H3 hexagons, analyze points of interest (POIs), 
+    and apply clustering for urban analysis.
+
+    Args:
+        PATH (str): Path to the base directory containing city data.
+        cities (Dict[str, Dict[str, Union[str, None]]]): A dictionary where keys 
+            are place IDs and values are dictionaries containing city-specific metadata 
+            (e.g., Nominatim strings or shapefile paths).
+        h3_zoom (int): H3 resolution level for generating hexagons.
+        snapthreshold (int): Distance threshold in meters for snapping centroids 
+            to the nearest network nodes.
+        sanidad_slider (float): Weight for the "sanidad" category POIs.
+        educacion_slider (float): Weight for the "educacion" category POIs.
+        administracion_slider (float): Weight for the "administracion" category POIs.
+        aprovisionamiento_slider (float): Weight for the "aprovisionamiento" category POIs.
+        cultura_slider (float): Weight for the "cultura" category POIs.
+        deporte_slider (float): Weight for the "deporte" category POIs.
+        transporte_slider (float): Weight for the "transporte" category POIs.
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If a category does not have a dictionary of POI types.
+        Exception: If there is an error processing a city's geometry.
+
+    Workflow:
+        1. Load and preprocess city geometries (from Nominatim or shapefiles).
+        2. Generate H3 hexagons for the city's region.
+        3. Intersect hexagons with points of interest (POIs) for each category, applying 
+           category-specific weights.
+        4. Perform clustering using Affinity Propagation based on POI density and 
+           location centroids.
+        5. Snap exemplar centroids to the nearest nodes in the city's transport network 
+           within a defined threshold.
+
+    Example Usage:
+        main(
+            PATH="path/to/data",
+            cities={
+                "city1": {"nominatimstring": "City, Country"},
+                "city2": {"nominatimstring": None}
+            },
+            h3_zoom=8,
+            snapthreshold=50,
+            sanidad_slider=1.0,
+            educacion_slider=1.2,
+            administracion_slider=0.8,
+            aprovisionamiento_slider=1.1,
+            cultura_slider=1.0,
+            deporte_slider=1.0,
+            transporte_slider=1.0
+        )
+    """
+
+    for placeid, placeinfo in tqdm(cities.items(), desc="Cities"):
+        print(PATH)
+
+        # Print place information
+        print(f"{placeid}: Loading location polygon and generating H3 hexagons")
+
+        ## grab polygon from prepare_pois.py 
+        # Check if 'nominatimstring' exists
+        if placeinfo["nominatimstring"]:
+            # Geocode to get the location geometry and extract relevant polygon
+            location = ox.geocoder.geocode_to_gdf(placeinfo["nominatimstring"])
+            location = fill_holes(extract_relevant_polygon(placeid, location.geometry.iloc[0]))
+        else:
+            # If shapefile is available, read and extract geometry
+            with fiona.open(f"../data/{placeid}/{placeid}.shp") as shp:
+                first = next(iter(shp))
+                try:
+                    location = Polygon(shapely.geometry.shape(first['geometry']))  # Handle if LineString is present
+                except Exception as e:
+                    print(f"Error processing geometry for {placeid}: {e}")
+                    continue  # Skip to the next city if there is an error
+
+        ######### to funtion
+        # Ensure `location` is a GeoDataFrame
+        gdf = gpd.GeoDataFrame(geometry=[location], crs="EPSG:4326")
+
+        # Define the H3 resolution
+        zoom = h3_zoom
+
+        # Convert the original geometries to H3 hexagons (assuming h3fy is defined)
+        gdf_hex = h3fy(gdf, resolution=zoom)
+
+        # Intersect the H3 hexagons with the original geometries
+        gdf_hex['geometry'] = gdf_hex.geometry.apply(
+            lambda x: gdf.geometry.unary_union.intersection(x) if x.is_valid else x
+        )
+
+        # Remove any invalid geometries
+        gdf_hex = gdf_hex[gdf_hex.geometry.is_valid & ~gdf_hex.geometry.is_empty]
+        print(gdf_hex)
+        
+        ###########
+
+        # Example categories definition as a dictionary
+        categories = {
+            "sanidad": sanidad,  # 'sanidad' should be a dictionary of POI types
+            "educacion": educacion,
+            "administracion": administracion,
+            "aprovisionamiento": aprovisionamiento,
+            "cultura": cultura,
+            "deporte": deporte,
+            "transporte": transporte
+        }
+
+        slider_weights = {
+            "sanidad": sanidad_slider,
+            "educacion": educacion_slider,
+            "administracion": administracion_slider,
+            "aprovisionamiento": aprovisionamiento_slider,
+            "cultura": cultura_slider,
+            "deporte": deporte_slider,
+            "transporte": transporte_slider
+        }
+
+        geodataframes = []
+
+        # Process POIs and perform spatial operations
+        for category_name, pois in categories.items():
+            if not isinstance(pois, dict):  # Validate that 'pois' is a dictionary
+                raise ValueError(f"Expected dictionary for category '{category_name}', got {type(pois)}")
+
+            for poi_type in pois.keys():  # Loop through each POI type in the category
+                poi_file = Path(PATH["data"]) / placeid / f"{placeid}_poi_{poi_type}.gpkg"
+                print(poi_file)
+                print(poi_file.exists())
+                if poi_file.exists():
+                    geo = gpd.read_file(poi_file)
+                    print(geo)
+                    geo["poi_source"] = poi_type  # Assign POI type (e.g., 'hospital')
+                    geo["category"] = category_name  # Assign category name (e.g., 'sanidad')
+                    geo["weight"] = slider_weights.get(category_name, 1)  # Assign slider weight
+                    geodataframes.append(geo)  # Add to the list of GeoDataFrames
+
+
+        # Combine all GeoDataFrames and perform spatial join
+        if geodataframes:
+            combined_geo = gpd.GeoDataFrame(pd.concat(geodataframes, ignore_index=True))
+            combined_geo = combined_geo.to_crs(gdf_hex.crs)
+
+            # Perform spatial join
+            hexagon_with_counts = gpd.sjoin(gdf_hex, combined_geo, how="inner", predicate="intersects")
+
+            # Apply weights to the point count
+            hexagon_with_counts["weighted_count"] = hexagon_with_counts["weight"]
+
+            # Aggregate weighted counts by hexagon
+            hexagon_counts = (
+                hexagon_with_counts.groupby("hex_id")["weighted_count"]
+                .sum()
+                .reset_index(name="weighted_point_count")
+            )
+
+            #gdf_hex = gdp.read_file("/media/M2_disk/roger/tomtom/data/h_index_geometries/gdf_hex_intersected.geojson")
+
+            # Merge the weighted counts back with the original hexagons
+            gdf_hex = gdf_hex.merge(hexagon_counts, on="hex_id", how="left").fillna(0)
+        
+        # Step 1: Extract centroids and point_count
+
+            gdf_hex["centroid"] = gdf_hex.geometry.centroid
+            centroids = np.array([(geom.x, geom.y) for geom in gdf_hex["centroid"]])
+            point_counts = gdf_hex["weighted_point_count"].values.reshape(-1, 1)
+
+            # Step 2: Standardize centroids and point_count
+            scaler = StandardScaler()
+            features = scaler.fit_transform(np.hstack([centroids, point_counts]))
+
+            # Step 3: Apply Affinity Propagation
+            ap = AffinityPropagation(random_state=42).fit(features)
+            gdf_hex["cluster"] = ap.labels_  # Assign cluster labels to hexagons
+
+            # Step 4: Identify exemplars and create exemplar label
+            exemplars_indices = ap.cluster_centers_indices_
+            gdf_hex["is_exemplar"] = 0  # Initialize all hexagons as non-exemplars
+            gdf_hex.loc[exemplars_indices, "is_exemplar"] = 1  # Mark exemplars
+
+            # Step 5: Create the final dataframe keeping centroids and exemplar labels
+            gdf_hex = gdf_hex[["geometry", "centroid", "weighted_point_count", "cluster", "is_exemplar"]]
+
+            # Step 6: Plot clusters and exemplars
+            ax = gdf_hex.plot(column="cluster", cmap="tab20", legend=True, alpha=0.5, figsize=(10, 6))
+            gdf_hex[gdf_hex["is_exemplar"] == 1].plot(ax=ax, color="red", markersize=50, label="Exemplars")
+            plt.legend()
+            plt.title("Affinity Propagation Clusters with Exemplars (Distance + Point Count)")
+            plt.show()
+            print(gdf_hex)
+
+        else:
+            print("No POI files found.")
+
+        print(gdf_hex)
+
+
+        # It may need to execute the first cell firts
+        # Define the snapping threshold (in meters)
+        snapthreshold = 50  # Adjust this value as needed
+
+        # Initialize a set to store snapped node IDs
+        nnids = set()
+        G_caralls = {}
+        G_caralls_simplified = {}
+        locations = {}
+        G_caralls[placeid] = csv_to_ox(PATH["data"] / placeid, placeid, 'carall')
+        G_caralls[placeid].graph["crs"] = 'epsg:4326'  # Assign CRS for OSMNX compatibility
+        G_caralls_simplified[placeid] = csv_to_ox(PATH["data"] / placeid, placeid, 'carall_simplified')
+        G_caralls_simplified[placeid].graph["crs"] = 'epsg:4326'
+
+        gdf = gpd.GeoDataFrame(gdf_hex[gdf_hex["is_exemplar"] == 1], geometry='centroid', crs="EPSG:4326")
+        G_carall = G_caralls[placeid]
+
+        # Snap points to the nearest nodes in the network
+        nnids = set()
+
+        for g in gdf['centroid']:
+            n = ox.distance.nearest_nodes(G_carall, g.x, g.y)
+            # Only snap if within the defined threshold
+            if n not in nnids and haversine((g.y, g.x), (G_carall.nodes[n]["y"], G_carall.nodes[n]["x"]), unit="m") <= snapthreshold:
+                nnids.add(n)
+
+        pass
+
+        nnids_file = Path(PATH["data"]) / placeid / f"{placeid}_nnids_sliders.csv"
+     
+        nnids_file.parent.mkdir(parents=True, exist_ok=True)
+        df = pd.DataFrame({"nnid": list(nnids)})
+        df.to_csv(nnids_file, index=False, header=False)
+
+        print(nnids)
+    
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Introduced a new script for placing nodes on a map leveraging user-defined sliders. Features include:

- Loading and preprocessing city geometries (Nominatim or shapefiles).
- Generating H3 hexagons and intersecting them with POIs across multiple categories.
- Applying user-adjustable slider weights for POI categories (e.g., health, education).
- Clustering with Affinity Propagation and snapping exemplar centroids to network nodes.

The script provides robust urban analysis capabilities through scalable data preprocessing and clustering logic.